### PR TITLE
Tidyups

### DIFF
--- a/src/fix/CMakeLists.txt
+++ b/src/fix/CMakeLists.txt
@@ -15,6 +15,7 @@ add_library(fixcodec SHARED
 set(FIX_CODEC_HEADERS
     fixCodec.h
     fixGroup.h
+    fixField.h
   )
 
 target_link_libraries (fixcodec cdr codechelpers fields xml2)

--- a/src/fix/fixCodec.cpp
+++ b/src/fix/fixCodec.cpp
@@ -722,11 +722,12 @@ fixCodec::encode (const cdr& d,
         checksum += ((char*)buf)[i]; 
 
     uint32_t cs = (unsigned int)(checksum % 256);
-    string sum;
-    utils_toString (cs, sum);
+
+    char s[4];
+    snprintf (s, sizeof (s), "%03d", cs);
 
     // write the checksum and we're done
-    return fixField::writeStringVal (CheckSum, sum, len, (char*)buf, used);
+    return fixField::writeStringVal (CheckSum, s, len, (char*)buf, used);
 }
 
 }

--- a/src/fix/fixField.h
+++ b/src/fix/fixField.h
@@ -32,7 +32,9 @@ class fixField
 public:
     fixField () :
         mRequired (false),
-        mTag (0)
+        mTag (0),
+        mGetter (NULL),
+        mSetter (NULL)
     {
         string t ("STRING");
         setType (t);

--- a/test/fix/fixCodecTest.cpp
+++ b/test/fix/fixCodecTest.cpp
@@ -7,6 +7,7 @@
 #include "cdr.h"
 #include "fields.h"
 #include "fixMsg.h"
+#include "utils.h"
 
 using namespace std;
 using namespace neueda;
@@ -34,8 +35,14 @@ protected:
     {
         mCodec = new fixCodec ();
         string err;
-        if (!mCodec->loadDataDictionary ("/Users/colinp/dev/cpp/scratch/FIX42.xml", err))
-            cout << err << endl;
+
+        string envVar ("CONFIG_PATH");
+        string filename ("FIX42.xml");
+        string dict;
+
+        ASSERT_TRUE (utils_findFileInEnvPath (envVar, filename, dict));
+
+        ASSERT_TRUE (mCodec->loadDataDictionary (dict.c_str (), err));
     }
 
     virtual void TearDown ()


### PR DESCRIPTION
Number of fixes and tidyups. 

- checksum not padded to 3 chars
- uninitialised variables in fixField.h
- fixField.h not installed
- unittest no longer using hard coded paths