### PR TITLE
Update cdr sub project and add missing CMake config

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,7 @@ option(PYTHON "Enable Python bindings" OFF)
 option(CSHARP "Enable C# bindings" OFF)
 option(COVERAGE "Enable gcov coverage" OFF)
 option(EXAMPLES "Enable compilation of examples" ON)
+set(PYTHON_CONFIG "python-config" CACHE STRING "python-config for build env config")
 
 if(WIN32)
   set(CMAKE_SHARED_LINKER_FLAGS "/FORCE:UNRESOLVED")
@@ -270,10 +271,10 @@ if(TESTS)
       CMAKE_ARGS -DBUILD_GMOCK=ON -DCMAKE_INSTALL_PREFIX=${CMAKE_BINARY_DIR}/googletest -DCMAKE_INSTALL_LIBDIR=${CMAKE_BINARY_DIR}/googletest/lib
       )
   endif()
-  
+
   include(CTest)
   enable_testing()
-  
+
   # add test dir
   add_subdirectory(test)
 endif()


### PR DESCRIPTION
- Noticed the jenkins build was failing due to the missing config option.
- Fixing that showed the old cdr build failure which required updating the sub module to pull in https://github.com/blu-corner/cdr/pull/31